### PR TITLE
Fix "class" --> "className" to resolve console error

### DIFF
--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -11,7 +11,7 @@ export default function Document() {
           <Link className="header" href="/">
             <Image alt="sdf" src="logo.svg" width={190} height={200} />
           </Link>
-          <div class="link-container">
+          <div className="link-container">
             <Link
               className="header"
               target="_blank"


### PR DESCRIPTION
Fixes an incorrect `class` that should be `className` to resolve error:
<img width="561" alt="image" src="https://github.com/stytchauth/stytch-nextjs-pages-router-example/assets/167120007/a8b34810-564a-40ee-8bd6-e9057b6d8621">
